### PR TITLE
update async-done

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "async": "~0.2.10",
-    "async-done": "~0.2.0",
+    "async-done": "~0.3.0",
     "async-settle": "~0.1.0",
     "async-time": "~0.0.1",
     "lodash": "~2.4.1"


### PR DESCRIPTION
Could we update `async-done`? Alternatively we could change it to  `"async-done": "^0.3.0"` to avoid this fine-grained bumping while things are still in the flux, WDYT?
