### PR TITLE
Handle non-functions passed as done parameter.

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -11,7 +11,9 @@ function getExtensions(lastArg) {
 }
 
 function buildOnSettled(done) {
-  done = done || _.noop;
+  if (typeof done !== 'function') {
+    done = _.noop;
+  }
 
   function onSettled(error, result) {
     if (error) {

--- a/test/onSettled.js
+++ b/test/onSettled.js
@@ -34,4 +34,9 @@ describe('onSettled', function() {
     onSettled()(null, errors);
     done();
   });
+
+  it('should handle non-functions as callbacks', function(done) {
+    onSettled('not a function')(null, errors);
+    done();
+  });
 });


### PR DESCRIPTION
So the behaviour is the same as the unsettled series/parallel.

Fixes crash in gulp running with the `--continue` flag in combination with watch tasks.
See: gulpjs/gulp#1488