### PR TITLE
Fix: coveralls badge in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ MIT
 [appveyor-image]: https://img.shields.io/appveyor/ci/gulpjs/bach.svg?label=appveyor
 
 [coveralls-url]: https://coveralls.io/r/gulpjs/bach
-[coveralls-image]: http://img.shields.io/coveralls/gulpjs/bach/master.svg
+[coveralls-image]: http://img.shields.io/coveralls/gulpjs/bach/v1.0.0.svg
 
 [gitter-url]: https://gitter.im/gulpjs/gulp
 [gitter-image]: https://badges.gitter.im/gulpjs/gulp.svg


### PR DESCRIPTION
This would solve #25 , **but** this badge will point to the branch `v1.0.0` on coveralls. So as soon there is a master on coveralls, it might not work.