### PR TITLE
Update: coveralls badge url

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ MIT
 [appveyor-image]: https://img.shields.io/appveyor/ci/gulpjs/bach.svg?label=appveyor
 
 [coveralls-url]: https://coveralls.io/r/gulpjs/bach
-[coveralls-image]: http://img.shields.io/coveralls/gulpjs/bach/master.svg
+[coveralls-image]: http://img.shields.io/coveralls/gulpjs/bach.svg
 
 [gitter-url]: https://gitter.im/gulpjs/gulp
 [gitter-image]: https://badges.gitter.im/gulpjs/gulp.svg


### PR DESCRIPTION
As you mentioned in https://github.com/gulpjs/bach/issues/25#issuecomment-280390595 the coveralls badge will no longer point to master.

The badge is still unknown - maybe it will show the right status after this got merged and travis trigger coveralls one more time.